### PR TITLE
trikboard: setup TMS320C674X DSP in the device-tree

### DIFF
--- a/arch/arm/boot/dts/trikboard.dts
+++ b/arch/arm/boot/dts/trikboard.dts
@@ -33,6 +33,28 @@
 		i2c2 = &i2c1;
 	};
 
+	memory {
+		device_type = "memory";
+		reg = <0xc0000000 0x08000000 0xcc000000 0x04000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		dsp_memory_region: dsp-memory@c3000000 {
+			compatible = "shared-dma-pool";
+			reg = <0xc3000000 0x1000000>;
+			reusable;
+			status = "okay";
+		};
+	};
+
+	dsp@11800000 {
+		status = "okay";
+	};
+
 	soc@1c00000 {
 		pmx_core: pinmux@14120 {
 			status = "okay";

--- a/drivers/media/usb/uvc/uvc_video.c
+++ b/drivers/media/usb/uvc/uvc_video.c
@@ -92,6 +92,10 @@ static void uvc_fixup_video_ctrl(struct uvc_streaming *stream,
 	struct uvc_format *format = NULL;
 	struct uvc_frame *frame = NULL;
 	unsigned int i;
+    
+	// Workaround for TRIK-specific musb implementation
+	// and Logitech c510 webcam
+	ctrl->dwMaxPayloadTransferSize = 600;
 
 	for (i = 0; i < stream->nformats; ++i) {
 		if (stream->format[i].index == ctrl->bFormatIndex) {


### PR DESCRIPTION
This PR:
- Adds workaround for Logitech C510 webcam
- Sets up DSP in trikboard device-tree file

Required to work with TMS320C674X DSP and to bring trik-media-sensors to the new kernel