### PR TITLE
Set memory-region for the DSP to 32 MB

### DIFF
--- a/arch/arm/boot/dts/trikboard.dts
+++ b/arch/arm/boot/dts/trikboard.dts
@@ -45,7 +45,7 @@
 
 		dsp_memory_region: dsp-memory@c3000000 {
 			compatible = "shared-dma-pool";
-			reg = <0xc3000000 0x1000000>;
+			reg = <0xc3000000 0x2000000>;
 			reusable;
 			status = "okay";
 		};
@@ -53,6 +53,7 @@
 
 	dsp@11800000 {
 		status = "okay";
+		memory-region = <&dsp_memory_region>;
 	};
 
 	soc@1c00000 {


### PR DESCRIPTION
This makes it easier to cache 16 MB lines.

It is not possible (explore this issue more deeply, mb possible) to cache the first line due to the resource table and metadata that are located at the beginning of the address. Therefore, we cache the second 16 MB out of 32MB for DSP algorithms.

[Description of the problem in carveout on the forum](https://e2e.ti.com/support/processors-group/processors/f/processors-forum/651383/linux-ipc-how-to-configure-dsp-memory-map-for-cache-with-linux-running-on-arm-on-omapl138#:~:text=Remoteproc%20was%20allocating,the%20cache%20requirement.).