### PR TITLE
Delete check cd gpio, fix i2c timeout

### DIFF
--- a/arch/arm/boot/dts/trikboard.dts
+++ b/arch/arm/boot/dts/trikboard.dts
@@ -60,12 +60,6 @@
 		pmx_core: pinmux@14120 {
 			status = "okay";
 
-			mmc0_cd_pin: pinmux_mmc0_cd {
-				pinctrl-single,bits = <
-					/* GP4[1] */
-					0x28 0x08000000 0x0f000000
-				>;
-			};
 			mmc1_pins: pinmux_mmc1_pins {
 				pinctrl-single,bits = <
 					/* GP6[9], MMCSD1_CLK, MMCSD1_CMD, MMCSD1_DAT[0-3] */
@@ -284,9 +278,10 @@
 		};
 		i2c0: i2c@22000 {
 			status = "okay";
-			clock-frequency = <10000>;
+			clock-frequency = <100000>;
 			pinctrl-names = "default";
 			pinctrl-0 = <&i2c0_pins>;
+			ti,has-pfunc;
 			ov7670d0: camera@21 {
 				pinctrl-names = "default";
 				/* jvp2 is channel 0, jvp1 is channel 1 ! */
@@ -306,7 +301,7 @@
 			clock-frequency = <100000>;
 			pinctrl-names = "default";
 			pinctrl-0 = <&i2c1_pins>;
-
+			ti,has-pfunc;
 			ov7670d1: camera@21 {
 				pinctrl-names = "default";
 				pinctrl-0 = <&pinctrl_reset_jvp1>;
@@ -363,9 +358,8 @@
 			max-frequency = <50000000>;
 			bus-width = <4>;
 			status = "okay";
-			cd-gpios = <&gpio 65 GPIO_ACTIVE_LOW>;
 			pinctrl-names = "default";
-			pinctrl-0 = <&mmc0_pins>, <&mmc0_cd_pin>;
+			pinctrl-0 = <&mmc0_pins>;
 		};
 		mmc1: mmc@21b000 {
 			max-frequency = <24000000>;

--- a/drivers/media/i2c/ov7670.c
+++ b/drivers/media/i2c/ov7670.c
@@ -1693,6 +1693,68 @@ static int ov7670_init_gpio(struct i2c_client *client, struct ov7670_info *info)
 	return 0;
 }
 
+#define ATTEMPTS_ACC_OV7670 5
+
+static ssize_t reinit_store(struct device *dev,
+                            struct device_attribute *attr,
+                            const char *buf, size_t count)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct v4l2_subdev *sd = i2c_get_clientdata(client);
+	struct ov7670_info *info = to_state(sd);
+    int val, ret, i;
+
+    if (kstrtoint(buf, 0, &val))
+        return -EINVAL;
+
+	if (val != 1)
+        return count;
+
+	for (i = 0; i < ATTEMPTS_ACC_OV7670; i++) {
+		ret = ov7670_detect(sd);
+		if (ret == 0) {
+			dev_info(dev, "successfull detect ov7670\n");
+			break;
+		}
+		// This logic is used mostly for i2c0, i2c1 works stably.
+		if (ret == -ETIMEDOUT) {
+			/* This error is possible if there are no interruptions
+
+			1) if the SCL or SDA are held in a low state, then they will 
+			be transferred to a high state and artificial clocking of the SCL is possible.
+
+			2) Also this can happen even with the bus running normally, there may be something wrong with the slave,
+			because there are no interruptions coming from it.
+			There is just a reinit (full reset) of the i2c module */
+			dev_warn(dev, "bus froze, should already be recovered, try again\n");
+			continue;
+		}
+		if (ret == -EREMOTEIO) {
+			/* For some reason, the first time when contacting the slave after 
+			reinit the i2c module and restoring the bus,
+			the slave sends a NACK and an EREMOTEIO error arrives, but immediately after that it says it is 
+			ready, sends ARDY and send signal STOP to i2c, so try again. */
+
+			dev_warn(dev, "the device is not connected or not responding, try again\n");
+			continue;
+		}
+		if (ret < 0) {
+			dev_err(dev, "error %d ov7670 detect\n", ret);
+			return ret;
+		}
+	}
+
+	if (i == ATTEMPTS_ACC_OV7670)
+		return -ETIME;
+	
+	if (info->pclk_hb_disable)
+		ov7670_write(sd, REG_COM10, COM10_PCLK_HB);
+
+    return count;
+}
+
+static DEVICE_ATTR_WO(reinit);
+
 static int ov7670_probe(struct i2c_client *client,
 			const struct i2c_device_id *id)
 {
@@ -1830,6 +1892,10 @@ static int ov7670_probe(struct i2c_client *client,
 	if (ret < 0)
 		goto hdl_free;
 
+	ret = device_create_file(&client->dev, &dev_attr_reinit);
+	if (ret)
+		dev_warn(&client->dev, "failed to create sysfs entry 'reinit'\n");
+
 	return 0;
 
 hdl_free:
@@ -1845,6 +1911,7 @@ static int ov7670_remove(struct i2c_client *client)
 	struct v4l2_subdev *sd = i2c_get_clientdata(client);
 	struct ov7670_info *info = to_state(sd);
 
+	device_remove_file(&client->dev, &dev_attr_reinit);
 	v4l2_device_unregister_subdev(sd);
 	v4l2_ctrl_handler_free(&info->hdl);
 	clk_disable_unprepare(info->clk);


### PR DESCRIPTION
1. Removed the gpio from the DT to detect the card in the card reader, since not all TRIK boards support this.

2. Fixed i2c timeout. Add bool parameter in DT for support recovery bus. This logic is used mostly for i2c0, i2c1 works stably.
Error is possible if there are no interruptions:
2.1 If the SCL or SDA are held in a low state, then they will be transferred to a high state and artificial clocking of the SCL is possible.
2.2 Also this can happen even with the bus running normally, there may be something wrong with the slave, because there are no interruptions coming from it. There is just a reinit (full reset) of the i2c module.

3. Add reinit file in sysfs for OV7670 so that it would be possible to connect the video module to the hot one and reinitialize it via i2c. The function also contains error handling logic when the i2c bus is stuck.