### PR TITLE
Support 2 gyro model on board

### DIFF
--- a/arch/arm/boot/dts/trikboard.dts
+++ b/arch/arm/boot/dts/trikboard.dts
@@ -419,7 +419,8 @@
 			l3gd20: l3gd20@0 {
 				pinctrl-names = "default";
 				pinctrl-0 = <&gyro_pins>;
-				compatible = "st,l3gd20-gyro";
+				// may be l3gd20 or l3gd20h
+				compatible = "st,l3gd20?-gyro";
 				spi-max-frequency = <10000000>;
 				reg = <0>;
 				st,drdy-int-pin = <2>;

--- a/drivers/iio/common/st_sensors/st_sensors_core.c
+++ b/drivers/iio/common/st_sensors/st_sensors_core.c
@@ -615,6 +615,58 @@ static int st_sensors_init_interface_mode(struct iio_dev *indio_dev,
 	return 0;
 }
 
+#define TRIK_L3GD20_GYRO_DEV_NAME		"l3gd20"
+#define TRIK_L3GD20H_GYRO_DEV_NAME		"l3gd20h"
+
+// We look at the chip model via WAI and look for the right device in the array.
+int st_sensors_detect_device_support(struct iio_dev *indio_dev,
+			int num_sensors_list,
+			const struct st_sensor_settings *sensor_settings)
+{
+	int i, err = 0;
+	u8 wai;
+	struct st_sensor_data *sdata = iio_priv(indio_dev);
+
+	err = sdata->tf->read_byte(&sdata->tb, sdata->dev,
+					   ST_SENSORS_DEFAULT_WAI_ADDRESS, &wai);
+	if (err < 0) {
+		dev_err(&indio_dev->dev,
+			"failed to read Who-Am-I register.\n");
+		return err;
+	}
+
+	for (i = 0; i < num_sensors_list; i++) {
+		if (sensor_settings[i].wai == wai) {
+			break;
+		}
+	}
+	if (i == num_sensors_list) {
+		dev_err(&indio_dev->dev, "WhoAmI (0x%x) device is not supported.\n",
+							wai);
+		return -ENODEV;
+	}
+
+	// this set name correct for TRIK with `l3gd20` or `l3gd20h` gyro on the board, 
+	// else name will be `l3gd20?`
+	// for other gyro models set correct compatible in device tree
+	if (wai == 0xd4) {
+		indio_dev->name = TRIK_L3GD20_GYRO_DEV_NAME;
+	} else if (wai == 0xd7) {
+		indio_dev->name = TRIK_L3GD20H_GYRO_DEV_NAME;
+	}
+
+	err = st_sensors_init_interface_mode(indio_dev, &sensor_settings[i]);
+	if (err < 0)
+		return err;
+
+	sdata->sensor_settings =
+			(struct st_sensor_settings *)&sensor_settings[i];
+
+	return i;
+}
+EXPORT_SYMBOL(st_sensors_detect_device_support);
+
+
 int st_sensors_check_device_support(struct iio_dev *indio_dev,
 			int num_sensors_list,
 			const struct st_sensor_settings *sensor_settings)

--- a/drivers/iio/gyro/st_gyro.h
+++ b/drivers/iio/gyro/st_gyro.h
@@ -20,6 +20,7 @@
 #define LSM330DLC_GYRO_DEV_NAME		"lsm330dlc_gyro"
 #define L3GD20_GYRO_DEV_NAME		"l3gd20"
 #define L3GD20H_GYRO_DEV_NAME		"l3gd20h"
+#define L3GD20_UNKNOWN_GYRO_DEV_NAME	"l3gd20?"
 #define L3G4IS_GYRO_DEV_NAME		"l3g4is_ui"
 #define LSM330_GYRO_DEV_NAME		"lsm330_gyro"
 #define LSM9DS0_GYRO_DEV_NAME		"lsm9ds0_gyro"

--- a/drivers/iio/gyro/st_gyro_core.c
+++ b/drivers/iio/gyro/st_gyro_core.c
@@ -367,9 +367,17 @@ int st_gyro_common_probe(struct iio_dev *indio_dev)
 	if (err)
 		return err;
 
-	err = st_sensors_check_device_support(indio_dev,
+	if (strcmp(indio_dev->name, L3GD20_UNKNOWN_GYRO_DEV_NAME) == 0) {
+		// in trik mb l3gd20 or l3gd20h, we need to detect by wai
+		err = st_sensors_detect_device_support(indio_dev,
+ 					ARRAY_SIZE(st_gyro_sensors_settings),
+ 					st_gyro_sensors_settings);
+	} else {
+		err = st_sensors_check_device_support(indio_dev,
 					ARRAY_SIZE(st_gyro_sensors_settings),
 					st_gyro_sensors_settings);
+	}
+
 	if (err < 0)
 		goto st_gyro_power_off;
 

--- a/drivers/iio/gyro/st_gyro_spi.c
+++ b/drivers/iio/gyro/st_gyro_spi.c
@@ -50,6 +50,11 @@ static const struct of_device_id st_gyro_of_match[] = {
 		.data = L3GD20H_GYRO_DEV_NAME,
 	},
 	{
+		// may be l3gd20 or l3gd20h
+		.compatible = "st,l3gd20?-gyro",
+		.data = L3GD20_UNKNOWN_GYRO_DEV_NAME,
+	},
+	{
 		.compatible = "st,l3g4is-gyro",
 		.data = L3G4IS_GYRO_DEV_NAME,
 	},

--- a/include/linux/iio/common/st_sensors.h
+++ b/include/linux/iio/common/st_sensors.h
@@ -326,6 +326,9 @@ int st_sensors_set_fullscale_by_gain(struct iio_dev *indio_dev, int scale);
 int st_sensors_read_info_raw(struct iio_dev *indio_dev,
 				struct iio_chan_spec const *ch, int *val);
 
+int st_sensors_detect_device_support(struct iio_dev *indio_dev,
+			int num_sensors_list, const struct st_sensor_settings *sensor_settings);
+
 int st_sensors_check_device_support(struct iio_dev *indio_dev,
 	int num_sensors_list, const struct st_sensor_settings *sensor_settings);
 


### PR DESCRIPTION
The TRIK can have 2 models of the l3gd20 or l3gd20h gyroscope on the board. They require different compatible option in device tree, so we made our UNKNOWN compatible and use the wai address to determine the model of the current gyroscope.